### PR TITLE
chore(fixing webpack compile issue):

### DIFF
--- a/frontend/src/components/ChordForm.js
+++ b/frontend/src/components/ChordForm.js
@@ -1,8 +1,8 @@
 import React, {useState, useRef} from "react"
 
-import ChordOption from "./ChordOption.js"
-import ExtensionOption from "./ExtensionOption.js"
-import InversionOption from "./InversionOption.js"
+import ChordOption from "./ChordOption"
+import ExtensionOption from "./ExtensionOption"
+import InversionOption from "./InversionOption"
 import { chordData, inversionData } from "../musicTheory/chordData"
 import {intervals, majorTriad, minorTriad, dimTriad, majorSeventh, minorSeventh, majorAdd9, minorAdd9, rootLookup, flavorLookup, chordBuilder} from "../musicTheory/chordGenerator"
 
@@ -33,7 +33,7 @@ const ChordForm = props =>{
                 {extension}
             </option>
         ))
-
+        
 // const states = countriesData
 // .find((item) => item.name === country)
 // ?.states.map((state) => (

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -5,14 +5,14 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.(js|jsx)$/,
+        test: /\.(js)$/,
         exclude: /node_modules/,
         use: ['babel-loader'],
       },
     ],
   },
   resolve: {
-    extensions: ['*', '.js', '.jsx'],
+    extensions: ['*', '.js'],
   },
   output: {
     path: path.resolve(__dirname, './public'),


### PR DESCRIPTION
Fix issue with webpack trying to make everything a jsx file, this is a typo from when we were going over this and fixed ChordForm to look more like it should.

going forward leave off the .js endings as if your importing with the file ending it means your importing the file not the module sorta.